### PR TITLE
Created deploy task to push or update application

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ The plugin adds the following tasks:
 * cf-unbind: Unbinds a service from an application
 * cf-add-user: Registers a user to the cloud
 * cf-delete-user: Unregisters the user from the cloud
+* cf-deploy: Pushes or Updates an application
 
 Configuring
 -----------
@@ -114,12 +115,12 @@ CloudFoundry has support for standalone applications. In that case, you must con
 For example:
 ```
 cloudfoundry {
-   target='http://api.vcap.me'
+   target = 'http://api.vcap.me'
    username = 'user@domain.com'
-   password='foobar'
+   password = 'foobar'
    application = 'myapp'
    framework = 'standalone'
-   applicationFramework='standalone'
+   applicationFramework = 'standalone'
    runtime = 'java'
    command = "$name/bin/$name"
    file = distZip.archivePath
@@ -127,6 +128,40 @@ cloudfoundry {
    memory = 256
 }
 ```
+
+Automated Deployment
+--------------------
+
+Regardless of whether you have a previously pushed app you can now execute 'gradle cf-deploy'.  This determines if
+your application exists already on cloudfoundry and runs the appropriate cf-push or cf-update task.
+
+If additional services are required by your application you can easily configure them to be created before the cf-deploy
+task executes like this:
+
+```
+tasks.'cf-deploy'.doFirst {
+    tasks['createMongoService'].execute()
+    tasks['createMySqlService'].execute()
+}
+
+task createMongoService(type: org.gradle.cf.AddServiceCloudFoundryTask) {
+    serviceName = 'mongo-service-1234567890'
+    vendor = 'mongodb'
+    version = '1.8'
+    tier = 'free'
+    username = 'user@domain.com'
+    password = 'foobar'
+}
+task createMySqlService(type: org.gradle.cf.AddServiceCloudFoundryTask) {
+    serviceName = 'mysql-service-1234567890'
+    vendor = 'mysql'
+    version = '5.1'
+    tier = 'free'
+    username = 'user@domain.com'
+    password = 'foobar'
+}
+```
+
 
 Future work
 -----------

--- a/src/main/groovy/org/gradle/cf/AbstractCloudFoundryTask.groovy
+++ b/src/main/groovy/org/gradle/cf/AbstractCloudFoundryTask.groovy
@@ -59,7 +59,7 @@ abstract class AbstractCloudFoundryTask extends DefaultTask {
                 throw e
             }
         } catch (ResourceAccessException e) {
-            throw new GradleException("Cannot access hotst at '${getTarget()}'.", e)
+            throw new GradleException("Cannot access host at '${getTarget()}'.", e)
         } finally {
             client = localClient
         }

--- a/src/main/groovy/org/gradle/cf/AbstractCreateApplicationCloudFoundryTask.groovy
+++ b/src/main/groovy/org/gradle/cf/AbstractCreateApplicationCloudFoundryTask.groovy
@@ -62,4 +62,8 @@ abstract class AbstractCreateApplicationCloudFoundryTask extends AbstractCloudFo
             throw new GradleException("You must choose memory size in this list $DEFAULT_MEMORY_SIZES")
         }
     }
+
+    List<String> getUniqueUris() {
+        return getUris().collect { it.toString() }.unique()
+    }
 }

--- a/src/main/groovy/org/gradle/cf/AddServiceCloudFoundryTask.groovy
+++ b/src/main/groovy/org/gradle/cf/AddServiceCloudFoundryTask.groovy
@@ -69,13 +69,27 @@ class AddServiceCloudFoundryTask extends AbstractCloudFoundryTask {
             if (!name) {
                 name = "${getVendor()}-service-${UUID.randomUUID().toString()[0..7]}"
             }
-            
-            // create service
-            log "Provisioning ${getVendor()} service '$name'"
-            client.createService(new CloudService(
-                    name: name, tier: getTier(), type: config.type,
-                    vendor: config.vendor, version: ver
-            ))
+
+            // Check if this service has already been created....  Can you have the same name but different types???
+            List<CloudService> cloudServices = client.getServices()
+            def cloudService = cloudServices.find {
+                it.name == name && it.type == config.type && it.vendor == config.vendor
+            }
+
+            if (cloudService) {
+                log "Service ${name} already exists for a ${config.vendor} service"
+                log "\tName: ${cloudService.name}"
+                log "\tVendor: ${cloudService.vendor}"
+                log "\tType: ${cloudService.type}"
+                log "\tVersion: ${cloudService.version}"
+            } else {
+                // create service
+                log "Provisioning ${getVendor()} service '$name'"
+                client.createService(new CloudService(
+                        name: name, tier: getTier(), type: config.type,
+                        vendor: config.vendor, version: ver
+                ))
+            }
             
             // bind if necessary
             if (isBind()) {

--- a/src/main/groovy/org/gradle/cf/CloudFoundryPlugin.groovy
+++ b/src/main/groovy/org/gradle/cf/CloudFoundryPlugin.groovy
@@ -44,6 +44,7 @@ class CloudFoundryPlugin implements Plugin<Project> {
         project.task('cf-update', type: UpdateApplicationCloudFoundryTask)
         project.task('cf-add-user', type: AddUserCloudFoundryTask)
         project.task('cf-delete-user', type: DeleteUserCloudFoundryTask)
+        project.task('cf-deploy', type: DeployApplicationCloudFoundryTask)
 
         // initiate properties
         project.tasks.withType(AbstractCloudFoundryTask).each { task ->

--- a/src/main/groovy/org/gradle/cf/DeployApplicationCloudFoundryTask.groovy
+++ b/src/main/groovy/org/gradle/cf/DeployApplicationCloudFoundryTask.groovy
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2012 the original author or authors.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.cf
+
+import org.cloudfoundry.client.lib.CloudApplication
+import org.cloudfoundry.client.lib.CloudFoundryException
+import org.cloudfoundry.client.lib.Staging
+import org.gradle.api.GradleException
+import org.gradle.api.tasks.TaskAction
+import org.springframework.http.HttpStatus
+
+/**
+ * Tasks used to determine if push or update is of an application on the CloudFoundry is required.
+ *
+ * @author Tim Redding
+ */
+class DeployApplicationCloudFoundryTask extends AbstractCreateApplicationCloudFoundryTask {
+
+    DeployApplicationCloudFoundryTask() {
+        super()
+        description = 'Deploys an application to the cloud'
+    }
+
+    @TaskAction
+    void deploy() {
+        connectToCloudFoundry()
+
+        if (!client) {
+            return
+        }
+
+        boolean found = true
+        try {
+            client.getApplication(getApplication())
+        } catch (CloudFoundryException e) {
+            if (HttpStatus.NOT_FOUND == e.statusCode) {
+                found = false;
+            } else {
+                throw new GradleException("Unable to retrieve application info from CloudFoundry", e)
+            }
+        }
+        if (found) {
+            log "Application ${getApplication()} found"
+            getProject().getTasksByName('cf-update', false).each { it.execute() }
+        } else {
+            log "Application ${getApplication()} not found"
+            getProject().getTasksByName('cf-push', false).each { it.execute() }
+        }
+    }
+}

--- a/src/main/groovy/org/gradle/cf/PushApplicationCloudFoundryTask.groovy
+++ b/src/main/groovy/org/gradle/cf/PushApplicationCloudFoundryTask.groovy
@@ -59,10 +59,10 @@ class PushApplicationCloudFoundryTask extends AbstractCreateApplicationCloudFoun
                 def staging = new Staging(getApplicationFramework()?:'standalone')
                 staging.runtime = getRuntime()
                 staging.command = getCommand()
-                client.createApplication(getApplication(), staging, getMemory(), getUris(), getServices())
+                client.createApplication(getApplication(), staging, getMemory(), getUniqueUris(), getServices())
             } else {
                 log "Creating application '${getApplication()}'"
-                client.createApplication(getApplication(), getFramework(), getMemory(), getUris(), getServices())
+                client.createApplication(getApplication(), getFramework(), getMemory(), getUniqueUris(), getServices())
             }
             
             log "Deploying '${getFile()}'"


### PR DESCRIPTION
Hey,

This is a new task I created to make automating a deployment easier.  If the application already exists on CF then it executes the Update task, otherwise it executes the Push task.

With this I wanted to make service binding a breeze.  So now on the Update task, services only bind if the name is specified and already created on CF.   It checks for services on CF, only binding if they exist.  It doesn't unbind services not specified in the gradle script, but this wouldn't be hard to add if needs be.  I'm taking the non-destructive approach.

Also updated Push & Update tasks to use a duplicate free list of URIs to map to.  This also makes sure all the URIs are strings.  GStrings don't get cast to Strings which can cause an issue.

Finally made adding a service e.g. calling cf-add-service,  an idempotent operation. Meaning if you already have the service it won't create it again or blow up because it already exists.  This allows automation of service creation before the Deploy task using a doFirst configuration as documented in the README.md possible.

Hope you think its a worth while addition.

Tim.
